### PR TITLE
Added per-message line height

### DIFF
--- a/src/MessagesList.css
+++ b/src/MessagesList.css
@@ -7,6 +7,7 @@
   border-radius: 0.3rem;
   padding: 1em;
   margin: 1em;
+  line-height: 1.5;
 }
 
 .messagesList {


### PR DESCRIPTION
Tl;Dr
===
Added quick fix for issue #1. Just added a `line-height` of `1.5` to the `message` CSS class for better readability.